### PR TITLE
Fix ard_stats_mantelhaen_test() failure on R-devel

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # cardx 0.3.3.9000
 
+* Fixed bug in `ard_stats_mantelhaen_test()` where arguments were passed to `stats::mantelhaen.test()` positionally rather than by name, causing a test failure and incorrect results under R-devel. (#343)
+
 # cardx 0.3.3
 
 * Fixed bug in `extract_strata()` where parentheses in strata level labels were incorrectly stripped, e.g. `"Drug (B)"` was truncated to `"B"`. (#2388)

--- a/R/ard_stats_mantelhaen_test.R
+++ b/R/ard_stats_mantelhaen_test.R
@@ -77,11 +77,13 @@ ard_stats_mantelhaen_test <- function(data, by, variables, strata, ...) {
 .calc_mantelhaen_test <- function(data, by, variables, strata, mantelhaen.args) {
   cards::as_cards_fn(
     \(x, data, variables, ...) {
-      stats::mantelhaen.test(
-        x = x,
-        y = data[[by]],
-        z = data[[strata]],
-        mantelhaen.args
+      inject(
+        stats::mantelhaen.test(
+          x = x,
+          y = data[[by]],
+          z = data[[strata]],
+          !!!mantelhaen.args
+        )
       ) |>
         broom::tidy() |>
         dplyr::bind_cols(mantelhaen.args)


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Fixed bug in `ard_stats_mantelhaen_test()` where the assembled argument list was passed positionally to `stats::mantelhaen.test()` instead of being spliced into named arguments, causing a test failure on R-devel.

The helper `.calc_mantelhaen_test()` collected `alternative`, `correct`, `exact`, and `conf.level` into a named list (`mantelhaen.args`) and passed it as a single positional argument to `stats::mantelhaen.test()`. That list landed in the `alternative=` position. Older R releases tolerated the malformed call, but R-devel's stricter argument handling rejects it: the statistic is captured as `NULL`, and `cards::get_ard_statistics()` then fails with `attempt to set an attribute on NULL`. This was the only failing test in the CRAN checks, and only on R-devel flavors.

The fix wraps the call in `rlang::inject()` and splices the list with `!!!mantelhaen.args`, matching the argument-splicing pattern already used elsewhere in the package (e.g. `ard_stats_anova()`, `ard_regression_basic()`).

An audit of the sibling `ard_stats_*()` and `ard_survey_*()` functions found no other instances of this defect: they pass `...` directly to their underlying test call and only use `dots_list(...)` to record arguments in the ARD.

CRAN checks: https://cran.r-project.org/web/checks/check_results_cardx.html

**Reference GitHub issue associated with pull request.**


--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [x] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [x] If a bug was fixed, a unit test was added.
- [x] If a new `ard_*()` function was added, it passes the ARD structural checks from `cards::check_ard_structure()`.
- [x] If a new `ard_*()` function was added, `set_cli_abort_call()` has been set.
- [x] If a new `ard_*()` function was added and it depends on another package (such as, `broom`), `is_pkg_installed("broom")` has been set in the function call and the following added to the roxygen comments.
- [x] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cardx (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".